### PR TITLE
Add support for Feather Huzzah and other ESP8266 based boards

### DIFF
--- a/Adafruit_BMP183.cpp
+++ b/Adafruit_BMP183.cpp
@@ -18,7 +18,7 @@
 #ifdef __AVR__
     #include <util/delay.h>
 #endif
-#ifdef __SAM3X8E__
+#if defined(__SAM3X8E__) || defined(ESP8266)
     #define _delay_ms(t) delay(t)
 #endif
 #include <SPI.h>

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,7 @@
+Adafruit_BMP183	KEYWORD1
+begin	KEYWORD2
+getTemperature	KEYWORD2
+getPressure	KEYWORD2
+getAltitude	KEYWORD2
+readRawTemperature	KEYWORD2
+readRawPressure	KEYWORD2


### PR DESCRIPTION
Added support for ESP8266 based boards by reusing the same define for _delay_ms that the Due uses. 
I also added a keywords.txt while I was at it.
